### PR TITLE
FlexTimeCheck画面を追加する

### DIFF
--- a/src/flex-time-check.html
+++ b/src/flex-time-check.html
@@ -35,14 +35,15 @@
 
 <body onload="proc();">
     <h2>FlexTimeCheck</h2>
-    <p>
-        ※表示されるまで最大5秒ほどかかります。
-    </p>
+
     <div id="logined">
     </div>
     <div id="error">
     </div>
     <p>今月の勤怠</p>
+    <p>
+        ※表示されるまで最大5秒ほどかかります。
+    </p>
     <div id="success">
     </div>
     <script>
@@ -61,7 +62,7 @@
                 document.getElementById("error").style.visibility = "visible";
 
                 document.getElementById("error").textContent = '先にsetting画面から勤之助にログインをして下さい。';
-            }else{
+            } else {
                 document.getElementById("success").style.visibility = "hidden";
                 document.getElementById("logined").style.visibility = "visible";
                 document.getElementById("error").style.visibility = "hidden";

--- a/src/flex-time-check.html
+++ b/src/flex-time-check.html
@@ -71,9 +71,6 @@
 
             let loginId = localStorage.getItem('loginId');
             let loginPassword = localStorage.getItem('loginPassword');
-            console.log(loginId);
-            console.log(loginPassword);
-
             (async () => {
                 const browser = await puppeteer.launch({
                     args: [
@@ -104,7 +101,6 @@
                     fullPage: true
                 });
 
-                //取得してきた値を返す
                 const sucessMeesage = await page.$('.alert');
                 const message = await page.evaluate(body => body.innerHTML, sucessMeesage);
                 document.getElementById("error").style.visibility = "hidden";

--- a/src/flex-time-check.html
+++ b/src/flex-time-check.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="js">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>FlexTimeCheck</title>
+    <style type="text/css">
+        #error {
+            padding: 12px;
+            font-weight: 850;
+            color: #262626;
+            background: #FFEBE8;
+            border: 2px solid #990000;
+        }
+
+        #success {
+            padding: 12px;
+            font-weight: 850;
+            color: #262626;
+            background: #CCFFCC;
+            border: 2px solid rgb(62.4%, 100%, 62.4%);
+        }
+
+        #logined {
+            padding: 12px;
+            font-weight: 850;
+            color: #262626;
+            background: rgb(255, 231, 95);
+            border: 2px solid rgb(255, 244, 180);
+        }
+    </style>
+</head>
+
+<body onload="proc();">
+    <h2>FlexTimeCheck</h2>
+    <p>
+        ※表示されるまで最大5秒ほどかかります。
+    </p>
+    <div id="logined">
+    </div>
+    <div id="error">
+    </div>
+    <p>今月の勤怠</p>
+    <div id="success">
+    </div>
+    <script>
+        function proc() {
+            const puppeteer = require('puppeteer');
+
+            // 初期状態ではメッセージは非表示
+            document.getElementById("error").style.visibility = "hidden";
+            document.getElementById("success").style.visibility = "hidden";
+
+            // まだ勤之助にログインをしていない
+            console.log(localStorage.getItem('loginFlg'));
+            if (!localStorage.getItem('loginFlg')) {
+                document.getElementById("success").style.visibility = "hidden";
+                document.getElementById("logined").style.visibility = "hidden";
+                document.getElementById("error").style.visibility = "visible";
+
+                document.getElementById("error").textContent = '先にsetting画面から勤之助にログインをして下さい。';
+            }else{
+                document.getElementById("success").style.visibility = "hidden";
+                document.getElementById("logined").style.visibility = "visible";
+                document.getElementById("error").style.visibility = "hidden";
+
+                document.getElementById("logined").textContent = '勤之助にログイン済みです。';
+            }
+
+            let loginId = localStorage.getItem('loginId');
+            let loginPassword = localStorage.getItem('loginPassword');
+            console.log(loginId);
+            console.log(loginPassword);
+
+            (async () => {
+                const browser = await puppeteer.launch({
+                    args: [
+                        '--no-sandbox',
+                        '--disable-setuid-sandbox'
+                    ]
+                });
+
+                const page = await browser.newPage();
+                await page.goto('https://flex-time-check.lolipop.io/');
+                await page.screenshot({
+                    path: './screenshot/flext.png',
+                    fullPage: true
+                });
+
+                //フォーム入力
+                await page.type('input[name="user[id]"]', loginId);
+                await page.type('input[name="user[password]"]', loginPassword);
+                await page.screenshot({
+                    path: './screenshot/flext2.png',
+                    fullPage: true
+                });
+                // ログインする
+                const loginElement = await page.$('input[type=submit]');
+                await loginElement.click();
+                await page.screenshot({
+                    path: './screenshot/flex3.png',
+                    fullPage: true
+                });
+
+                //取得してきた値を返す
+                const sucessMeesage = await page.$('.alert');
+                const message = await page.evaluate(body => body.innerHTML, sucessMeesage);
+                document.getElementById("error").style.visibility = "hidden";
+                document.getElementById("success").style.visibility = "visible";
+                document.getElementById("success").textContent = message;
+
+                browser.close();
+            })();
+
+        }
+    </script>
+</body>
+
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,9 @@ let menuTemplate = [{
         { label: 'Setting', accelerator: 'CmdOrCtrl+,', click: function(){
             showSettingWindow();
         } },
+        { label: 'FlexTimeCheck', accelerator: 'CmdOrCtrl+T', click: function(){
+            showFlexTimeCheckWindow();
+        } },
         { type: 'separator'},
         { label: 'Quit', accelerator: 'CmdOrCtrl+C', click: function(){
             app.quit();
@@ -41,7 +44,6 @@ ipcMain.on('settings_attend', function(event, attend) {
 
 
 
-
 function showAboutDaialog(){
     dialog.showMessageBox({
         type: 'info',
@@ -55,6 +57,19 @@ function showSettingWindow(){
     // create window
     settingsWindow = new BrowserWindow({width: 600, height:400 });
     settingsWindow.loadURL('file://'+ __dirname + '/settings.html');
+    // chomeのツールを読み込む
+    settingsWindow.webContents.openDevTools();
+    settingsWindow.show();
+    // 閉じた際の処理
+    settingsWindow.on('closed', function(){
+        settingsWindow = null;
+    });
+}
+
+function showFlexTimeCheckWindow(){
+    // create window
+    settingsWindow = new BrowserWindow({width: 600, height:400 });
+    settingsWindow.loadURL('file://'+ __dirname + '/flex-time-check.html');
     // chomeのツールを読み込む
     settingsWindow.webContents.openDevTools();
     settingsWindow.show();

--- a/src/settings.html
+++ b/src/settings.html
@@ -76,19 +76,19 @@
                     path: './screenshot/login.png',
                     fullPage: true
                 });
-                const buttonElement = await page.$('input[type=submit]');
+                const loginElement = await page.$('input[type=submit]');
                 // ログインする
-                await buttonElement.click();
+                await loginElement.click();
                 await page.screenshot({
                     path: './screenshot/logined.png',
                     fullPage: true
                 });
 
-                const isLoginErro = await page.$('#wrapper_main .txt_15_b_message_red') || false;
+                const isLoginError = await page.$('#wrapper_main .txt_15_b_message_red') || false;
 
-                if (isLoginErro) {
+                if (isLoginError) {
                     // ログイン失敗
-                    const erroMessage = await page.evaluate(body => body.innerHTML, isLoginErro);
+                    const erroMessage = await page.evaluate(body => body.innerHTML, isLoginError);
                     document.getElementById("success").style.visibility = "hidden";
                     document.getElementById("error").style.visibility = "visible";
                     document.getElementById("error").textContent = `${erroMessage}`;

--- a/src/settings.html
+++ b/src/settings.html
@@ -91,8 +91,8 @@
                     const erroMessage = await page.evaluate(body => body.innerHTML, isLoginErro);
                     document.getElementById("success").style.visibility = "hidden";
                     document.getElementById("error").style.visibility = "visible";
-                    ''
                     document.getElementById("error").textContent = `${erroMessage}`;
+                    return 0;
                 } else {
                     // ログイン成功
                     document.getElementById("error").style.visibility = "hidden";

--- a/src/settings.html
+++ b/src/settings.html
@@ -23,12 +23,22 @@
             background: #CCFFCC;
             border: 2px solid #00CC00;
         }
+
+        #logined {
+            padding: 12px;
+            font-weight: 850;
+            color: #262626;
+            background: rgb(255, 231, 95);
+            border: 2px solid rgb(255, 244, 180);
+        }
     </style>
 </head>
 
 <body>
     <h1>勤之助ログイン画面</h1>
     <!-- フォーム画面 -->
+    <div id="logined">
+    </div>
     <div id="error">
     </div>
     <div id="success">
@@ -40,6 +50,23 @@
     <input id="password" type="password" value="">
     <p><button id="login-btn">決定</button></p>
     <!-- <script src="login.js"></script> -->
+    <script>
+        window.onload = function onLoad() {
+            // まだ勤之助にログインをしていない
+            if (!localStorage.getItem('loginFlg')) {
+                document.getElementById("success").style.visibility = "hidden";
+                document.getElementById("logined").style.visibility = "hidden";
+                document.getElementById("error").style.visibility = "visible";
+
+                document.getElementById("error").textContent = '勤之助にログインをして下さい。';
+            }else{
+                document.getElementById("success").style.visibility = "hidden";
+                document.getElementById("logined").style.visibility = "visible";
+                document.getElementById("error").style.visibility = "hidden";
+                document.getElementById("logined").textContent = '勤之助にログイン済みです。';
+            }
+        }
+    </script>
     <script>
         const puppeteer = require('puppeteer');
 

--- a/src/settings.html
+++ b/src/settings.html
@@ -52,12 +52,10 @@
     <!-- <script src="login.js"></script> -->
     <script>
         window.onload = function onLoad() {
-            // まだ勤之助にログインをしていない
             if (!localStorage.getItem('loginFlg')) {
                 document.getElementById("success").style.visibility = "hidden";
                 document.getElementById("logined").style.visibility = "hidden";
                 document.getElementById("error").style.visibility = "visible";
-
                 document.getElementById("error").textContent = '勤之助にログインをして下さい。';
             }else{
                 document.getElementById("success").style.visibility = "hidden";

--- a/src/settings.html
+++ b/src/settings.html
@@ -88,6 +88,8 @@
 
                 if (isLoginError) {
                     // ログイン失敗
+                    localStorage.setItem('loginFlg', false);
+
                     const erroMessage = await page.evaluate(body => body.innerHTML, isLoginError);
                     document.getElementById("success").style.visibility = "hidden";
                     document.getElementById("error").style.visibility = "visible";
@@ -95,10 +97,17 @@
                     return 0;
                 } else {
                     // ログイン成功
+                    localStorage.setItem('loginFlg', true);
+
                     document.getElementById("error").style.visibility = "hidden";
                     document.getElementById("success").style.visibility = "visible";
                     document.getElementById("success").textContent = '勤之助にログインできました!';
                 }
+
+                //認証に成功した値をlocalStorageにいれる。
+                localStorage.setItem('loginId', loginId);
+                localStorage.setItem('loginPassword', loginPassword);
+                browser.close();
             })();
         });
     </script>

--- a/src/settings.html
+++ b/src/settings.html
@@ -51,10 +51,6 @@
         login_btn.addEventListener('click', function () {
             let login = document.getElementById('id').value;
             let password = document.getElementById('password').value;
-
-            console.log(`id:${login}です`);
-            console.log(`password:${password}です`);
-
             (async () => {
                 const browser = await puppeteer.launch({
                     args: [


### PR DESCRIPTION
### 何を解決するのか

勤之助リマインダーでもFlexTimeCheckが確認できるようにする画面を作成します。

こんな感じです。

![image](https://user-images.githubusercontent.com/13227145/45184285-7b007700-b261-11e8-8f77-960c40e441b8.png)


### 詳細

内部実装は引き続き、pupetterを使って[FlexTimeCheck](https://flex-time-check.lolipop.io/check)にWebスクレイピングをして勤怠時間を取得してきてます。この画面の最大の特徴としては、これからはサイトにいかなくても`Cmd+T`で勤怠が確認できるようになった事です。

### レビューポイント

(レビュアーに pull request のレビューのポイントを書きます)

### レビュアー

(pull request のレビュアーを決めてメンションします)

### 期限

(日にちや時間で指定。もしくは、速orゆっくりかを書きます)
